### PR TITLE
intervention_effect 0.0.17 2022-01-29: disabled fill_in_asymptotics_interventional_probabilities (crashes)

### DIFF
--- a/R/intervention_effect.R
+++ b/R/intervention_effect.R
@@ -1,4 +1,6 @@
 ## Changelog:
+# MH 0.0.17 2022-01-29: disabled fill_in_asymptotics_interventional_
+#                       probabilities (crashes)
 # CG 0.0.16 2022-01-13: changed structure of internal_list
 #                       cleaned up code (documentation, 80 char per line)
 #                       changed dot-case to snake-case
@@ -178,8 +180,8 @@ intervention_effect <- function(model, intervention, intervention_level,
   # Calculates interventional probability
   # internal_list <- interventional_probability( internal_list = internal_list )
   # MH 0.0.11 2021-11-22, call changed from interventional_probability to
-  # fill_in_interventional_probabilities
- internal_list <- fill_in_interventional_probabilities( internal_list = 
+  #   fill_in_interventional_probabilities
+  internal_list <- fill_in_interventional_probabilities( internal_list = 
                                                         internal_list )
 
   #
@@ -207,9 +209,36 @@ intervention_effect <- function(model, intervention, intervention_level,
  internal_list <- fill_in_asymptotics_interventional_density( internal_list = 
                                                               internal_list )
   
- internal_list <- 
-   fill_in_asymptotics_interventional_probabilities( internal_list = 
-                                                      internal_list )
+
+
+  # MH 0.0.17 2022-01-29 disabled, crashes with call:
+  #    intervention_effect( model=o00_lavaan_test_object,intervention="x2",
+  #                         intervention_level=2)
+  # error message:
+  #   Fehler in stats::dnorm(lower_bounds, mean = outcome_mean,
+  #                        sd = outcome_std) : 
+  #   Nicht-numerisches Argument für mathematische Funktion  
+  # traceback:
+  #   4: stats::dnorm(lower_bounds, mean = outcome_mean, sd = outcome_std)
+               # at calculate_jacobian_interventional_probabilities.R#133
+  #   3: calculate_jacobian_interventional_probabilities(model = internal_list, 
+       # x = internal_list$info_interventions$intervention_levels, 
+       # intervention_names = internal_list$info_interventions$
+	   #                                                   intervention_names, 
+       # outcome_names = internal_list$info_interventions$outcome_names, 
+       # lower_bounds = internal_list$info_interventions$lower_bounds, 
+       # upper_bounds = internal_list$info_interventions$upper_bounds, 
+       # verbose = verbose) at fill_in_asymptotics_interventional_
+	   #                                                    probabilities.R#46
+  #   2: fill_in_asymptotics_interventional_probabilities(internal_list =
+       #                            internal_list) at intervention_effect.R#210
+  #   1: intervention_effect(model = o00_lavaan_test_object, intervention =
+       #                                                                  "x2", 
+       # intervention_level = 2)
+
+ # internal_list <- 
+   # fill_in_asymptotics_interventional_probabilities( internal_list = 
+                                                      # internal_list )
   
   
 

--- a/R/plot_distributions.R
+++ b/R/plot_distributions.R
@@ -1,0 +1,410 @@
+## Changelog:
+# MH 0.0.1 2022-01-29: initial programming
+
+## Documentation
+#' @title Plot distributions
+#' @description Function that generates distribution plots
+#' @param object The object returned from calling
+#'        function \code{intervention_effect}.
+#' @param plot logical, if TRUE plots are displayed
+#' @param plot directory, directory to save pdf plot files
+#' @return \code{plot_distributions} returns ggplot2 code
+#'         for density plots
+#' @references Gische, C., Voelkle, M.C. (2021) Beyond the mean: a
+#'             flexible framework for studying causal effects using linear
+#'             models. Psychometrika (advanced online publication).
+#'             https://doi.org/10.1007/s11336-021-09811-z
+
+## Function definition
+plot_distributions <- function( object, plot=TRUE, plot.dir=NULL ){
+
+	# function name
+	fun.name <- "plot_distributions"
+
+	# function version
+	fun.version <- "0.0.1 2022-01-29"
+
+	# function name+version
+	fun.name.version <- paste0( fun.name, " (", fun.version, ")" )
+
+	# get verbose argument
+	verbose <- object$control$verbose
+
+	# console output
+	if( verbose >= 2 ) cat( paste0( "start of function ", fun.name.version,
+							" ", Sys.time(), "\n" ) )
+
+	# packages
+	require( reshape2 )
+	require( ggplot2 )
+	require( gridExtra )
+
+	
+	### declarations
+
+	# names of outcome variables
+	outvars <- object$info_interventions$outcome_names
+	
+	# names of intervention variables
+	intvars <- object$info_interventions$intervention_names
+	
+	# intervention levels
+	intlevels <- object$info_interventions$intervention_levels
+
+	# get data (lavaan only!!)
+	d <- as.data.frame( lavInspect( object$fitted_object, "data" ) )
+
+	
+	### sampling statistics
+	smplstat <- data.frame( "outvar"=outvars, 
+							"mean"=sapply( d[,outvars], mean ),
+							"sd"=sapply( d[,outvars], sd ),
+							"stat"="smpl" )
+	
+	
+	### conditional statistics
+	
+	# lm model strings
+	lm.strs <- paste0( "lm( ", outvars, " ~ ", 
+						paste( intvars, collapse=" + " ), ", data=d )" )
+	
+	# estimate lm models
+	fitted.l <- sapply( lm.strs, function( str ) eval( parse( text=str ) ),
+						simplify=FALSE )
+
+	# make data frame for intervention levels (for lm prediction)
+	int.long <- data.frame( "intvar"=intvars, "intlevel"=intlevels )
+	int.wide <- dcast( int.long, . ~ intvar, value.var="intlevel" )[,-1,
+															drop=FALSE]
+
+	# mean predictions
+	cond.mean <- unname( sapply( fitted.l, function( fitted ) 
+							predict.lm( object=fitted, newdata=int.wide ),
+							simplify=TRUE ) )
+	
+	# sd
+	cond.sd <- unname( sapply( fitted.l, sigma, simplify=TRUE ) )
+
+	# conditional statistics data frame
+	condstat <- data.frame( "outvar"=outvars, 
+							"mean"=cond.mean,
+							"sd"=cond.sd,
+							"stat"="cond" )
+	
+
+	### causal statistics
+	
+	# mean
+	causal.mean <- object$tables$interventional_means$Est.
+	# for safeness: sort again supposedly already sorted vector
+	names( causal.mean ) <- object$tables$interventional_means$Variable
+	causal.mean <- causal.mean[ outvars ]
+
+	# sd
+	causal.sd <- sqrt( object$tables$interventional_variances$Est. )
+	# for safeness: sort again supposedly already sorted vector
+	names( causal.sd ) <- object$tables$interventional_variances$Variable
+	causal.sd <- causal.sd[ outvars ]
+	
+	# causal statistics data frame
+	causalstat <- data.frame( "outvar"=outvars, 
+							  "mean"=causal.mean,
+							  "sd"=causal.sd,
+							  "stat"="causal" )
+	
+	
+	### data frame with all stats
+	stat <- do.call( "rbind", list( smplstat, condstat, causalstat ) )
+	
+	# factors
+	stat$outvar <- factor( stat$outvar, levels=outvars )
+	stat$stat   <- factor( stat$stat, levels=c("smpl","cond","causal") )
+	
+	# sort
+	stat <- stat[,c("outvar","stat","mean","sd")]
+	stat <- stat[ order( stat$outvar, stat$stat ), ]
+	rownames( stat ) <- seq( along=rownames( stat ) )
+
+	
+	### data frame with x values ("grid") and y values (pdf values)
+	
+	# generate x values and calculate pdfs for each variable, return list
+	l <- mapply( function( outvar, stat, mean, sd ){
+
+							# generate x-axis values
+							x <- seq( -3*sd, 3*sd, length.out=200 ) + mean
+
+							# get pdf values
+							pdf.values <- dnorm( x, mean=mean, sd=sd )
+
+							# data frame for distribution line
+							d <- data.frame( "outvar"=outvar, "stat"=stat,
+							            "x"=x, "pdf.values"=pdf.values )
+										
+							# data frame for shaded 95% area
+							s <- d[ d$x > ( qnorm(0.025)*sd + mean ) &
+							               d$x < ( -qnorm(0.025)*sd + mean ), ]
+
+							# data frame for mean, q025, q975
+							x2 <- c( mean,
+							         qnorm(0.025)*sd + mean,
+									 -qnorm(0.025)*sd + mean )
+							m <- data.frame( "outvar"=outvar, "stat"=stat,
+											 "q"=c("mean","q025","q975"),
+											 "x"=x2,
+											 "pdf.values"=
+													 sapply( x2, function( x )
+													 dnorm(x,mean=mean,sd=sd) )
+											)
+							# return
+							return( list( d, s, m ) )
+
+					}, stat$outvar, stat$stat, stat$mean, stat$sd,
+					                                           SIMPLIFY=FALSE )
+	# complete data frame for distribution lines
+	pdf <- do.call( "rbind", sapply( l, "[", 1 ) )
+	# complete data frame for shaded 95% areas
+	s95 <- do.call( "rbind", sapply( l, "[", 2 ) )
+	# complete data frame for mean, q025, q975
+	m <- do.call( "rbind", sapply( l, "[", 3 ) )
+	
+	# factors
+	pdf$outvar <- factor( pdf$outvar, levels=levels( stat$outvar ) )
+	s95$outvar <- factor( s95$outvar, levels=levels( stat$outvar ) )
+	pdf$stat   <- factor( pdf$stat,   levels=levels( stat$stat ) )
+	s95$stat   <- factor( s95$stat,   levels=levels( stat$stat ) )
+	
+	# count the number of integer digits
+	# https://stackoverflow.com/questions/47190693/
+	#                                        count-the-number-of-integer-digits
+	n_int_digits = function(x) {
+	  result = floor(log10(abs(x)))
+	  result[!is.finite(result)] = 0
+	  result
+	}
+
+	### x breaks
+	# get all x values
+	# allx <- unname( do.call( "c", sapply( xnames, function( xname )
+	#                                  pdf[[xname]][,"x"], simplify=FALSE ) ) )
+	allx <- pdf$x
+	
+	# extremest absolute value
+	extremex <- max( abs( min( allx ) ), abs( max( allx ) ) )
+	extrx.ndig <- n_int_digits( extremex )		
+	extrx <- round( max( abs( min( allx ) ), abs( max( allx ) ) ), -extrx.ndig)
+	
+	# lowest break
+	if( min( allx ) < 0 ){
+		xlow <- -extrx
+	} else {
+		xlow <- min( allx )
+	}
+
+	# highest break
+	if( max( allx ) < 0 ){
+		xhigh <- max( allx )
+	} else {
+		xhigh <- extrx
+	}
+
+	# x breaks/labs
+	x.breaks <- c( seq( xlow, xhigh, length.out=11 ) )
+	x.labs <- formatC( x.breaks, format="f", digits=ifelse( extrx.ndig > 0, 0,
+																-extrx.ndig ) )
+
+	### y breaks
+	# ally <- unname( do.call( "c", sapply( xnames, function( xname ) c(	
+												# pdf[[xname]][,"pdf.values"],
+												# pdf[[xname]][,"UL95"],
+												# pdf[[xname]][,"LL95"] ),
+												# simplify=FALSE ) ) )
+	ally <- pdf$pdf.values
+
+	# lowest break
+	ylow <- min( ally )
+
+	# highest break
+	yhigh <- max( ally )
+
+	# extremest absolute value
+	extremey <- max( abs( min( ally ) ), abs( max( ally ) ) )
+	extry.ndig <- n_int_digits( extremey )		
+	
+	## y breaks/labs
+	seq.start <- ifelse( ylow<0, ylow, 0 )
+	y.breaks <- c( seq( seq.start, yhigh+diff(range(ally))*0.01, length.out=5))
+	y.labs <- formatC( y.breaks, format="f", digits=ifelse( extry.ndig > 0, 0,
+	                                                          -extry.ndig+1 ) )
+	# lowest y limit is the UL95, no label
+	y.labs[1] <- ""
+
+	# theme
+	theme <- theme_bw() +
+         theme( axis.title=element_text(size=14, face="bold"),
+                axis.text=element_text(size=14, colour="black"),
+                panel.grid=element_blank(),
+                # panel.grid.major=element_line(colour="lightgrey", size=0.25),
+                panel.grid.major=element_blank(),
+                panel.grid.minor=element_blank(),
+                legend.text=element_text(size=12),
+                legend.title=element_text(size=14, face = "bold"),
+                legend.justification=c(1,1),
+                legend.position=c(0.98,0.98),
+                legend.key=element_rect(linetype=0),
+                legend.key.height=unit(15, "points"),
+                legend.key.width=unit(40, "points"),
+                legend.spacing.x=unit(0, "points"),
+                strip.text.x=element_text(size=12, face="bold"),
+                strip.text.y=element_text(size=12, face="bold"),
+                strip.background=element_rect(colour="black", fill="white"),
+                plot.background=element_rect(fill="white"),
+                plot.title=element_text(face="bold", size=16),
+				strip.text.y.left=element_text(angle = 0)
+               )
+
+	### function to generate distribution plot
+	# inspired by https://sebastiansauer.github.io/shade_Normal_curve/
+	#             https://sebastiansauer.github.io/normal_curve_ggplot2/
+	gen.distribution.plot <- function( outvar ){
+
+		# data
+		pdf.  <- pdf[ pdf$outvar %in% outvar, ]
+		s95.  <- s95[ s95$outvar %in% outvar, ]
+		stat. <- stat[ stat$outvar %in% outvar, ]
+		m. <- m[ m$outvar %in% outvar, ]
+		m.$x2 <- 0
+		
+		# strip labels
+		stat.labs <- c( paste0( "P(", outvar, ")" ),
+						paste0( "P(", outvar, "|", paste( 
+											paste0( intvars, "=", intlevels ) ,
+											collapse="," ) , ")" ),
+						paste0( "P(", outvar, "|do(", paste(
+											paste0( intvars, "=", intlevels ) ,
+											collapse="," ) , "))" )
+                        )
+		names( stat.labs ) <- levels( pdf.$stat )
+
+		# generate plot
+		p <- ggplot( data=pdf., aes( x=x, y=pdf.values ) )
+		p <- p + geom_segment(data=m., aes(x=x, y=0, xend=x, yend=pdf.values))
+		p <- p + geom_line()
+		p <- p + geom_area( data=s95., fill = "#000000",
+					            color = NA, alpha = 0.20 )
+		p <- p + facet_wrap( ~ stat,
+							   ncol=1,               
+							   nrow=3,               
+							   strip.position="top",
+							   labeller = labeller( stat = stat.labs ) )
+		p <- p + scale_x_continuous( limits=c(x.breaks[1],
+									 x.breaks[length(x.breaks)]),
+									 breaks=x.breaks, labels=x.labs,
+									 expand = expansion( mult = c(0, 0),
+									                     add=c(0, 0) ) )
+		p <- p + scale_y_continuous( limits=c(y.breaks[1],
+		                             y.breaks[length(y.breaks)]),
+									 breaks=y.breaks,
+									 labels=y.labs,
+									 expand = expansion( mult = c(0, 0),
+									                     add=c(0, 0) ) )
+		p <- p + xlab( paste0( "\n", outvar ) )
+		p <- p + ylab( "density function\n" )
+		p <- p + theme
+		# https://stackoverflow.com/questions/18252827/
+		#                           increasing-area-around-plot-area-in-ggplot2
+		# top right bottom left
+		p <- p + theme( plot.margin = unit(c(15.5, 25.5, 5.5, 5.5), "points") )
+		
+		# return plot
+		return( p )
+	}
+
+	# generate plots
+	p.l <- sapply( outvars, gen.distribution.plot, simplify=FALSE )
+
+	# plot the plots
+	if( plot ) {
+		for( p in p.l ){
+			dev.new()
+			plot( p )
+		}
+	}
+	
+	# output pdf plots
+	if( !is.null( plot.dir ) && is.character( plot.dir ) && 
+	                              dir.exists( plot.dir ) &&
+								  ( file.access( plot.dir, mode=2 ) %in% 0 ) ){
+	
+		# single plots (one for each non-interventional variable)
+		for( i in seq( along = p.l ) ){
+			p <- p.l[[i]]
+			plot.path <- file.path( plot.dir, paste0( "distribution_plot_",
+			                                        names( p.l )[i], ".pdf" ) )
+			ggsave( plot.path, p, width=297/1.5, height=297, units="mm" )
+		}
+	
+		# all single plots in one plot 
+		plots <- arrangeGrob( grobs=p.l,ncol=1 )
+		if( !plot ) dev.off()
+		plot.path2 <- file.path( plot.dir, paste0( "distribution_plot_",
+		                        paste( names( p.l ), collapse="_" ), ".pdf" ) )
+		ggsave( plot.path2, plots, width=297/1.5, height=0+length(p.l)*250,
+		                                                           units="mm" )
+	
+	}
+	
+	# console output
+	if( verbose >= 2 ) cat( paste0( "  end of function ", fun.name.version,
+	                                                  " ", Sys.time(), "\n" ) )
+
+	# return list of plots
+	return( p.l )
+}
+
+### development
+# user.profile <- shell( "echo %USERPROFILE%", intern=TRUE )
+# Rfiles.folder <- file.path( user.profile,
+                            # "Dropbox/68_causalSEM/04_martinhecht/R" )
+# Rfiles <- list.files( Rfiles.folder , pattern="*.R" )
+# Rfiles <- Rfiles[ !Rfiles %in% "plot_distributions.R" ]
+# for( Rfile in Rfiles ){
+	# source( file.path( Rfiles.folder, Rfile ) )
+# }
+
+
+## test object 00_lavaan_test_object
+# load( file.path( user.profile, 
+      # "Dropbox/causalSEM_R_Package/test_object/00_lavaan_test_object.Rdata"))
+# object00 <- intervention_effect(model=o00_lavaan_test_object,
+#									   intervention="x2", intervention_level=2)
+# p.l <- plot_distributions( object00,plot.dir="c:/users/martin/Desktop/plots")
+
+
+## test object 01_lavaan_test_object
+# load( file.path( user.profile, 
+      # "Dropbox/causalSEM_R_Package/test_object/01_lavaan_test_object.Rdata"))
+# object01 <- intervention_effect( model=o01_lavaan_test_object,
+#									   intervention="x2", intervention_level=2)
+# p.l <- plot_distributions( object01,plot.dir="c:/users/martin/Desktop/plots")
+
+
+## test object 02_lavaan_test_object
+# load( file.path( user.profile, 
+      # "Dropbox/causalSEM_R_Package/test_object/02_lavaan_test_object.Rdata"))
+# object02 <- intervention_effect( model=o02_lavaan_test_object,
+#									   intervention="x2", intervention_level=2)
+# p.l <- plot_distributions(object02, plot.dir="c:/users/martin/Desktop/plots")
+
+
+## test object 03_lavaan_test_object
+# load( file.path( user.profile, 
+      # "Dropbox/causalSEM_R_Package/test_object/03_lavaan_test_object.Rdata"))
+# object03 <- intervention_effect( model=o03_lavaan_test_object,
+#									   intervention="x2", intervention_level=2)
+# p.l <- plot_distributions( object03,plot.dir="c:/users/martin/Desktop/plots")
+
+
+### test
+# require( testthat )
+# test_file("../tests/testthat/XXXXX.R")

--- a/R/plot_interventional_density.R
+++ b/R/plot_interventional_density.R
@@ -1,4 +1,7 @@
 ## Changelog:
+# MH 0.0.4 2022-01-30:
+#    -- minor mod of y.breaks calculation
+#    -- lines all < 80 chars
 # MH 0.0.3 2021-11-22:
 #    -- moved grid calculation from interventional_density.R to here
 #    -- renamed from plot_density to plot_interventional_density
@@ -10,10 +13,12 @@
 ## Documentation
 #' @title Plot density
 #' @description Function that generates density plots
-#' @param object The object returned from calling function \code{intervention_effect}.
+#' @param object The object returned from calling function
+#'     \code{intervention_effect}.
 #' @param plot logical, if TRUE plots are displayed
 #' @param plot directory, directory to save pdf plot files
-#' @return \code{plot_interventional_density} returns ggplot2 code for density plots
+#' @return \code{plot_interventional_density} returns ggplot2 code for
+#'     density plots
 #' @references
 #' @references Gische, C., Voelkle, M.C. (2021) Beyond the mean: a flexible 
 #' framework for studying causal effects using linear models. Psychometrika 
@@ -35,14 +40,16 @@ plot_interventional_density <- function( object, plot=TRUE, plot.dir=NULL ){
 	verbose <- object$control$verbose
 
 	# console output
-	if( verbose >= 2 ) cat( paste0( "start of function ", fun.name.version, " ", Sys.time(), "\n" ) )
+	if( verbose >= 2 ) cat( paste0( "start of function ", fun.name.version,
+	                                                  " ", Sys.time(), "\n" ) )
 	
 	# packages
 	require( ggplot2 )
 	require( gridExtra )
 		
-	###################################################################################
-	# MH 0.0.3 2021-11-22, moved grid calculation from interventional_density.R to here
+	###########################################################################
+	# MH 0.0.3 2021-11-22, moved grid calculation from
+	#    interventional_density.R to here
 	
 	# get intervential mean and variance
 	E <- object$interventional_distribution$means$values
@@ -52,7 +59,8 @@ plot_interventional_density <- function( object, plot=TRUE, plot.dir=NULL ){
 	sds <- sqrt( diag( V ) )
 
 	# generate x values and calculate pdfs for each variable, return list
-	pdf <- mapply( function( mean, sd, outcome_names, intervention_names, verbose ){
+	pdf <- mapply( function( mean, sd, outcome_names, intervention_names,
+	                                                                 verbose ){
 
 							# generate x-axis values
 							x <- seq( -3*sd, 3*sd, length.out=200 ) + mean
@@ -65,21 +73,25 @@ plot_interventional_density <- function( object, plot=TRUE, plot.dir=NULL ){
 							# TEST DUMMY
 							se <- rep( 0.001, length( x ) )
 							
-							# MH 0.0.3 2021-11-22, calculate_ase_interventional_density crashes
-							# kein Slot des Namens "internal" für dieses Objekt der Klasse "lavaan"
-							# mapply( function( x, pdf.value ) calculate_ase_interventional_density( model=object,
-																								   # x=x,
-																								   # y=pdf.value,
-																								   # intervention_names=intervention_names,
-																								   # outcome_names=outcome_names,
-																								   # verbose=verbose ),
-																								   # x, pdf.values, MoreArgs=list("model"=object,"verbose"=verbose) )
-							# calculate_ase_interventional_density( model=object,
-																  # x=-0.1694369,
-																  # y=0.03549121,
-																  # intervention_names="x2",
-																  # outcome_names="x1",
-																  # verbose=TRUE )
+							# MH 0.0.3 2021-11-22, 
+							#    calculate_ase_interventional_density crashes
+							#    kein Slot des Namens "internal" für dieses
+							#    Objekt der Klasse "lavaan"
+							#    mapply( function( x, pdf.value )
+				# calculate_ase_interventional_density( model=object,
+						   # x=x,
+						   # y=pdf.value,
+						   # intervention_names=intervention_names,
+						   # outcome_names=outcome_names,
+						   # verbose=verbose ),
+						   # x, pdf.values, MoreArgs=list("model"=object,
+						   #                               "verbose"=verbose) )
+				# calculate_ase_interventional_density( model=object,
+											  # x=-0.1694369,
+											  # y=0.03549121,
+											  # intervention_names="x2",
+											  # outcome_names="x1",
+											  # verbose=TRUE )
 							
 
 							# 95% CI
@@ -87,10 +99,17 @@ plot_interventional_density <- function( object, plot=TRUE, plot.dir=NULL ){
 							UL95 <- pdf.values + qnorm(0.975)*se
 
 							# return
-							as.matrix( data.frame( "x"=x, "pdf.values"=pdf.values, "se"=se, "LL95"=LL95, "UL95"=UL95 ) )
+							as.matrix( data.frame( "x"=x,
+							                       "pdf.values"=pdf.values,
+												   "se"=se,
+												   "LL95"=LL95,
+												   "UL95"=UL95 ) )
 
-					}, E[,1], sds, names(E[,1]), MoreArgs=list("intervention_names"=object$info_interventions$intervention_names,"verbose"=verbose), SIMPLIFY=FALSE )	
-	###################################################################################
+					}, E[,1], sds, names(E[,1]), 
+MoreArgs=list(
+"intervention_names"=object$info_interventions$intervention_names,
+                                           "verbose"=verbose), SIMPLIFY=FALSE )	
+	###########################################################################
 	
 	# theme
 	theme <- theme_bw() +
@@ -120,12 +139,13 @@ plot_interventional_density <- function( object, plot=TRUE, plot.dir=NULL ){
 	xnames <- object$info_model$var_names
 	
 	# omit interventional variables for plotting
-	xnames <- xnames[ !xnames %in% object$info_interventions$intervention_names ]
+	xnames <- xnames[!xnames %in% object$info_interventions$intervention_names]
 	
 	if( length( xnames ) > 0 ){
 
 		# count the number of integer digits
-		# https://stackoverflow.com/questions/47190693/count-the-number-of-integer-digits
+		# https://stackoverflow.com/questions/47190693/
+		#                                    count-the-number-of-integer-digits
 		n_int_digits = function(x) {
 		  result = floor(log10(abs(x)))
 		  result[!is.finite(result)] = 0
@@ -135,14 +155,18 @@ plot_interventional_density <- function( object, plot=TRUE, plot.dir=NULL ){
 
 		### x breaks
 		# get all x values
-		# allx <- unname( do.call( "c", sapply( xnames, function( xname ) object$interventional_distribution$density$pdf[[xname]][,"x"], simplify=FALSE ) ) )
+		# allx <- unname( do.call( "c", sapply( xnames, function( xname )
+		#        object$interventional_distribution$density$pdf[[xname]][,"x"],
+		#                                                  simplify=FALSE ) ) )
 		# MH 0.0.3 2021-11-22, now "pdf"
-		allx <- unname( do.call( "c", sapply( xnames, function( xname ) pdf[[xname]][,"x"], simplify=FALSE ) ) )
+		allx <- unname( do.call( "c", sapply( xnames, function( xname )
+		                               pdf[[xname]][,"x"], simplify=FALSE ) ) )
 		
 		# extremest absolute value
 		extremex <- max( abs( min( allx ) ), abs( max( allx ) ) )
 		extrx.ndig <- n_int_digits( extremex )		
-		extrx <- round( max( abs( min( allx ) ), abs( max( allx ) ) ), -extrx.ndig )
+		extrx <- round( max( abs( min( allx ) ), abs( max( allx ) ) ),
+		                                                          -extrx.ndig )
 		
 		# lowest break
 		if( min( allx ) < 0 ){
@@ -160,19 +184,23 @@ plot_interventional_density <- function( object, plot=TRUE, plot.dir=NULL ){
 
 		# x breaks/labs
 		x.breaks <- c( seq( xlow, xhigh, length.out=11 ) )
-		x.labs <- formatC( x.breaks, format="f", digits=ifelse( extrx.ndig > 0, 0, -extrx.ndig ) )
+		x.labs <- formatC( x.breaks, format="f",
+		                      digits=ifelse( extrx.ndig > 0, 0, -extrx.ndig ) )
 
 		### y breaks
 		# get all y values (incl. bounds of 95% CI)
-		# ally <- unname( do.call( "c", sapply( xnames, function( xname ) c(	object$interventional_distribution$density$pdf[[xname]][,"pdf.values"],
-																			# object$interventional_distribution$density$pdf[[xname]][,"UL95"],
-																			# object$interventional_distribution$density$pdf[[xname]][,"LL95"] ),
-																			# simplify=FALSE ) ) )
+		# ally <- unname( do.call( "c", sapply( xnames, function( xname ) 
+	#c(object$interventional_distribution$density$pdf[[xname]][,"pdf.values"],
+		# object$interventional_distribution$density$pdf[[xname]][,"UL95"],
+	 	# object$interventional_distribution$density$pdf[[xname]][,"LL95"] ),
+		# simplify=FALSE ) ) )
+		
 		# MH 0.0.3 2021-11-22, now "pdf"
-		ally <- unname( do.call( "c", sapply( xnames, function( xname ) c(	pdf[[xname]][,"pdf.values"],
-																			pdf[[xname]][,"UL95"],
-																			pdf[[xname]][,"LL95"] ),
-																			simplify=FALSE ) ) )
+		ally <- unname( do.call( "c", sapply( xnames, function( xname )
+											c(	pdf[[xname]][,"pdf.values"],
+											pdf[[xname]][,"UL95"],
+											pdf[[xname]][,"LL95"] ),
+											simplify=FALSE ) ) )
 
 		# lowest break
 		ylow <- min( ally )
@@ -185,8 +213,14 @@ plot_interventional_density <- function( object, plot=TRUE, plot.dir=NULL ){
 		extry.ndig <- n_int_digits( extremey )		
 		
 		## y breaks/labs
-		y.breaks <- c( ylow, seq( 0, yhigh, length.out=11 ) )
-		y.labs <- formatC( y.breaks, format="f", digits=ifelse( extry.ndig > 0, 0, -extry.ndig+1 ) )
+		# y.breaks <- c( ylow, seq( 0, yhigh, length.out=11 ) )
+		# MH 0.0.4 2022-01-30
+		seq.start <- ifelse( ylow<0, ylow, 0 )
+		y.breaks <- c( seq( seq.start, yhigh+diff(range(ally))*0.01,
+																 length.out=5))
+		
+		y.labs <- formatC( y.breaks, format="f", digits=ifelse( extry.ndig > 0,
+														   0, -extry.ndig+1 ) )
 		# lowest y limit is the UL95, no label
 		y.labs[1] <- ""
 
@@ -195,22 +229,36 @@ plot_interventional_density <- function( object, plot=TRUE, plot.dir=NULL ){
 		gen.density.plot <- function( xname ){
 		
 			# data
-			# d <- as.data.frame( object$interventional_distribution$density$pdf[[xname]] )
+			# d <- as.data.frame( 
+			#         object$interventional_distribution$density$pdf[[xname]] )
 			# MH 0.0.3 2021-11-22, now "pdf"
 			d <- as.data.frame( pdf[[xname]] )
 
 			# generate plot
 			p <- ggplot( data=d, aes( y=pdf.values, x=x ) )
 			p <- p + geom_line()
-			p <- p + geom_ribbon( aes( ymin=LL95, ymax=UL95, x=x ), alpha = 0.2, color=NA, show.legend=FALSE )
-			p <- p + scale_x_continuous( limits=c(x.breaks[1], x.breaks[length(x.breaks)]), breaks=x.breaks, labels=x.labs, expand = expansion(mult = c(0, 0), add=c(0, 0) ) )
-			p <- p + scale_y_continuous( limits=c(y.breaks[1], y.breaks[length(y.breaks)]), breaks=y.breaks, labels=y.labs, expand = expansion(mult = c(0, 0), add=c(0, 0) ) )
+			p <- p + geom_ribbon( aes( ymin=LL95, ymax=UL95, x=x ), alpha=0.2,
+												  color=NA, show.legend=FALSE )
+			p <- p + scale_x_continuous( limits=c(x.breaks[1],
+												  x.breaks[length(x.breaks)]),
+												  breaks=x.breaks,
+												  labels=x.labs,
+												  expand = expansion(
+												  mult = c(0, 0), add=c(0, 0)))
+			p <- p + scale_y_continuous( limits=c(y.breaks[1],
+												  y.breaks[length(y.breaks)]),
+												  breaks=y.breaks,
+												  labels=y.labs,
+												  expand = expansion(
+												  mult = c(0, 0), add=c(0, 0)))
 			p <- p + xlab( paste0( "\n", xname ) )
 			p <- p + ylab( "interventional pdf\n" )
 			p <- p + theme
-			# https://stackoverflow.com/questions/18252827/increasing-area-around-plot-area-in-ggplot2
+			# https://stackoverflow.com/questions/18252827/
+			#						increasing-area-around-plot-area-in-ggplot2
 			# top right bottom left
-			p <- p + theme( plot.margin = unit(c(15.5, 25.5, 5.5, 5.5), "points") )
+			p <- p + theme( plot.margin = unit(c(15.5, 25.5, 5.5, 5.5),
+																	"points") )
 			
 			# return plot
 			return( p )
@@ -228,69 +276,94 @@ plot_interventional_density <- function( object, plot=TRUE, plot.dir=NULL ){
 		}
 
 		# output pdf plots
-		if( !is.null( plot.dir ) && is.character( plot.dir ) && dir.exists( plot.dir ) && ( file.access( plot.dir, mode=2 ) %in% 0 ) ){
+		if( !is.null( plot.dir ) && is.character( plot.dir ) &&
+									  dir.exists( plot.dir ) &&
+								  ( file.access( plot.dir, mode=2 ) %in% 0 ) ){
 
 			# single plots (one for each non-interventional variable)
 			for( i in seq( along = p.l ) ){
 				p <- p.l[[i]]
-				plot.path <- file.path( plot.dir, paste0( "density_plot_", names( p.l )[i], ".pdf" ) )
+				plot.path <- file.path( plot.dir, paste0( "density_plot_",
+													names( p.l )[i], ".pdf" ) )
 				ggsave( plot.path, p, width=297, height=297, units="mm" )
 			}
 
 			# all single plots in one plot 
 			plots <- arrangeGrob( grobs=p.l,ncol=1 )
 			if( !plot ) dev.off()
-			plot.path2 <- file.path( plot.dir, paste0( "density_plot_", paste( names( p.l ), collapse="_" ), ".pdf" ) )
-			ggsave( plot.path2, plots, width=297, height=0+length(p.l)*250, units="mm" )
+			plot.path2 <- file.path( plot.dir, paste0( "density_plot_",
+								paste( names( p.l ), collapse="_" ), ".pdf" ) )
+			ggsave( plot.path2, plots, width=297, height=0+length(p.l)*250,
+																   units="mm" )
 
 		}
 	
 	} else {
 		# console output
-		# if( verbose >= 2 ) cat( paste0( "nothing to plot, names(object$interventional_distribution$density$pdf) does not include any non-interventional variables", "\n" ) )
+		# if( verbose >= 2 ) cat( paste0( "nothing to plot,
+		#     names(object$interventional_distribution$density$pdf) does not
+		#     include any non-interventional variables", "\n" ) )
 		# MH 0.0.3 2021-11-22, now "pdf"
-		if( verbose >= 2 ) cat( paste0( "nothing to plot, names(pdf) does not include any non-interventional variables", "\n" ) )
+		if( verbose >= 2 ) cat( paste0( "nothing to plot, names(pdf) does not
+		                    include any non-interventional variables", "\n" ) )
 		
 		# return object NULL
 		p.l <- NULL
 	}
 	
 	# console output
-	if( verbose >= 2 ) cat( paste0( "  end of function ", fun.name.version, " ", Sys.time(), "\n" ) )
+	if( verbose >= 2 ) cat( paste0( "  end of function ", fun.name.version," ",
+														   Sys.time(), "\n" ) )
 
 	# return list of plots
 	return( p.l )
 }
 
 ### development
-# Rfiles <- list.files( "c:/Users/martin/Dropbox/68_causalSEM/04_martinhecht/R", pattern="*.R" )
+# user.profile <- shell( "echo %USERPROFILE%", intern=TRUE )
+# Rfiles.folder <- file.path( user.profile,
+                            # "Dropbox/68_causalSEM/04_martinhecht/R" )
+# Rfiles <- list.files( Rfiles.folder , pattern="*.R" )
 # Rfiles <- Rfiles[ !Rfiles %in% "plot_interventional_density.R" ]
 # for( Rfile in Rfiles ){
-	# source( Rfile )
+	# source( file.path( Rfiles.folder, Rfile ) )
 # }
 
+
 ## test object 00_lavaan_test_object
-# load( file.path( shell( "echo %USERPROFILE%", intern=TRUE ), "Dropbox/causalSEM_R_Package/test_object/00_lavaan_test_object.Rdata" ) )
-# object00 <- intervention_effect( model=o00_lavaan_test_object,intervention="x2",intervention_levels=2)
-# p.l <- plot_interventional_density( object00, plot.dir="c:/users/martin/Desktop/plots" )
+# load( file.path( shell( "echo %USERPROFILE%", intern=TRUE ), 
+	  # "Dropbox/causalSEM_R_Package/test_object/00_lavaan_test_object.Rdata"))
+# object00 <- intervention_effect( model=o00_lavaan_test_object,
+									# intervention="x2",intervention_level=2)
+# p.l <- plot_interventional_density( object00,
+									# plot.dir="c:/users/martin/Desktop/plots")
 
 
 ## test object 01_lavaan_test_object
-# load( file.path( shell( "echo %USERPROFILE%", intern=TRUE ), "Dropbox/causalSEM_R_Package/test_object/01_lavaan_test_object.Rdata" ) )
-# object01 <- intervention_effect( model=o01_lavaan_test_object,intervention="x2",intervention_levels=2)
-# p.l <- plot_interventional_density( object01, plot.dir="c:/users/martin/Desktop/plots" )
+# load( file.path( shell( "echo %USERPROFILE%", intern=TRUE ), 
+	  # "Dropbox/causalSEM_R_Package/test_object/01_lavaan_test_object.Rdata"))
+# object01 <- intervention_effect( model=o01_lavaan_test_object,
+									# intervention="x2",intervention_level=2)
+# p.l <- plot_interventional_density( object01,
+									# plot.dir="c:/users/martin/Desktop/plots")
 
 
 ## test object 02_lavaan_test_object
-# load( file.path( shell( "echo %USERPROFILE%", intern=TRUE ), "Dropbox/causalSEM_R_Package/test_object/02_lavaan_test_object.Rdata" ) )
-# object02 <- intervention_effect( model=o02_lavaan_test_object,intervention="x2",intervention_levels=2)
-# p.l <- plot_interventional_density( object02, plot.dir="c:/users/martin/Desktop/plots" )
+# load( file.path( shell( "echo %USERPROFILE%", intern=TRUE ), 
+	  # "Dropbox/causalSEM_R_Package/test_object/02_lavaan_test_object.Rdata"))
+# object02 <- intervention_effect( model=o02_lavaan_test_object,
+									# intervention="x2",intervention_level=2)
+# p.l <- plot_interventional_density( object02,
+									# plot.dir="c:/users/martin/Desktop/plots")
 
 
 ## test object 03_lavaan_test_object
-# load( file.path( shell( "echo %USERPROFILE%", intern=TRUE ), "Dropbox/causalSEM_R_Package/test_object/03_lavaan_test_object.Rdata" ) )
-# object03 <- intervention_effect( model=o03_lavaan_test_object,intervention="x2",intervention_levels=2)
-# p.l <- plot_interventional_density( object03, plot.dir="c:/users/martin/Desktop/plots" )
+# load( file.path( shell( "echo %USERPROFILE%", intern=TRUE ), 
+	  # "Dropbox/causalSEM_R_Package/test_object/03_lavaan_test_object.Rdata"))
+# object03 <- intervention_effect( model=o03_lavaan_test_object,
+									# intervention="x2",intervention_level=2)
+# p.l <- plot_interventional_density( object03,
+									# plot.dir="c:/users/martin/Desktop/plots")
 
 
 ### test


### PR DESCRIPTION
disabled fill_in_asymptotics_interventional_probabilities (crashes)

  # MH 0.0.17 2022-01-29 disabled, crashes with call:
  #    intervention_effect( model=o00_lavaan_test_object,intervention="x2",
  #                         intervention_level=2)
  # error message:
  #   Fehler in stats::dnorm(lower_bounds, mean = outcome_mean,
  #                        sd = outcome_std) : 
  #   Nicht-numerisches Argument für mathematische Funktion  
  # traceback:
  #   4: stats::dnorm(lower_bounds, mean = outcome_mean, sd = outcome_std)
               # at calculate_jacobian_interventional_probabilities.R#133
  #   3: calculate_jacobian_interventional_probabilities(model = internal_list, 
       # x = internal_list$info_interventions$intervention_levels, 
       # intervention_names = internal_list$info_interventions$
	   #                                                   intervention_names, 
       # outcome_names = internal_list$info_interventions$outcome_names, 
       # lower_bounds = internal_list$info_interventions$lower_bounds, 
       # upper_bounds = internal_list$info_interventions$upper_bounds, 
       # verbose = verbose) at fill_in_asymptotics_interventional_
	   #                                                    probabilities.R#46
  #   2: fill_in_asymptotics_interventional_probabilities(internal_list =
       #                            internal_list) at intervention_effect.R#210
  #   1: intervention_effect(model = o00_lavaan_test_object, intervention =
       #                                                                  "x2", 
       # intervention_level = 2)